### PR TITLE
hide red no power icon

### DIFF
--- a/prototypes/radioisotopes/radioisotopes-entities.lua
+++ b/prototypes/radioisotopes/radioisotopes-entities.lua
@@ -19,6 +19,7 @@ data:extend(
 				input_flow_limit = "0kW",
 				output_flow_limit = "300kW",
 				emissions = 0.01,
+				render_no_power_icon = false,
 			},
 			energy_production = "300kW",
 			energy_usage = "0kW",


### PR DESCRIPTION
from https://forums.factorio.com/viewtopic.php?f=95&t=43759
```
Update 2018-3-18, version 0.2.5.
Update all mods to latest versions
Replace tin with steel in yellow belts and splitters
Updated KS Power removes red flashing power icon from wind turbines
```

from https://github.com/Klonan/KS_Power/commit/e7bec6800715eea7c5b8f5f61c42bdb03fbf3a65#diff-36cf308098b3ef72b13922a63b4444abR48